### PR TITLE
Sf4.4 patch for username

### DIFF
--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -58,6 +58,7 @@ class PredisParametersFactory
         if ($dsn->getUsername() !== null) {
             $options['username'] = $dsn->getUsername();
         }
+
         if ($dsn->getDatabase() !== null) {
             $options['database'] = $dsn->getDatabase();
         }

--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -58,7 +58,6 @@ class PredisParametersFactory
         if ($dsn->getUsername() !== null) {
             $options['username'] = $dsn->getUsername();
         }
-        
         if ($dsn->getDatabase() !== null) {
             $options['database'] = $dsn->getDatabase();
         }

--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -55,6 +55,10 @@ class PredisParametersFactory
             }
         }
 
+        if ($dsn->getUsername() !== null) {
+            $options['username'] = $dsn->getUsername();
+        }
+        
         if ($dsn->getDatabase() !== null) {
             $options['database'] = $dsn->getDatabase();
         }


### PR DESCRIPTION
Patched version for passing in username to predis factory, maintaining compatibility with symfony 4.4 (temporarily, needs to be upgraded soon).